### PR TITLE
Add fix for streams being started but not marked live

### DIFF
--- a/src/provider/youtube.js
+++ b/src/provider/youtube.js
@@ -94,7 +94,7 @@ function _lookupInternal(id, cached) {
     const url = new URL('https://www.googleapis.com/youtube/v3/videos');
     url.search = new URLSearchParams({
         key: API_KEY,
-        part: 'contentDetails,status,snippet',
+        part: 'contentDetails,status,snippet,liveStreamingDetails',
         id
     });
 
@@ -175,7 +175,11 @@ function _lookupInternal(id, cached) {
                 // is presumably correct (we don't care about duration
                 // for livestreams anyways)
                 // See calzoneman/sync#710
-                if (video.snippet.liveBroadcastContent !== 'live') {
+                //
+                // Sometimes, Youtube fails to set the status of a stream
+                // to live. However, we can check if 'actualStartTime' is
+                // present in the stream details to know it has started.
+                if (video.snippet.liveBroadcastContent !== 'live' && !video.liveStreamingDetails.actualStartTime) {
                     throw new Error(
                         'This video has not been processed yet.'
                     );

--- a/src/provider/youtube.js
+++ b/src/provider/youtube.js
@@ -178,8 +178,10 @@ function _lookupInternal(id, cached) {
                 //
                 // Sometimes, Youtube fails to set the status of a stream
                 // to live. However, we can check if 'actualStartTime' is
-                // present in the stream details to know it has started.
-                if (video.snippet.liveBroadcastContent !== 'live' && !video.liveStreamingDetails?.actualStartTime) {
+                // present in the stream details to know it has started,
+                // and 'actualEndTime' to know it's ended.
+                if (video.snippet.liveBroadcastContent !== 'live' &&
+                    (!video.liveStreamingDetails?.actualStartTime || video.liveStreamingDetails?.actualEndTime)) {
                     throw new Error(
                         'This video has not been processed yet.'
                     );

--- a/src/provider/youtube.js
+++ b/src/provider/youtube.js
@@ -179,7 +179,7 @@ function _lookupInternal(id, cached) {
                 // Sometimes, Youtube fails to set the status of a stream
                 // to live. However, we can check if 'actualStartTime' is
                 // present in the stream details to know it has started.
-                if (video.snippet.liveBroadcastContent !== 'live' && !video.liveStreamingDetails.actualStartTime) {
+                if (video.snippet.liveBroadcastContent !== 'live' && !video.liveStreamingDetails?.actualStartTime) {
                     throw new Error(
                         'This video has not been processed yet.'
                     );


### PR DESCRIPTION
Not sure how Youtube manages this. They can be seen at least from the Subscriptions page as being listed as a planned stream, but if you open the stream, it is live.
Currently when in this state, the stream cannot be queued in Cytube. The main workaround is to set a custom iframe embed, but this is not preferable.